### PR TITLE
Adding Christopher Clark to list of pledges

### DIFF
--- a/_includes/pledge.md
+++ b/_includes/pledge.md
@@ -13,3 +13,4 @@
 - [Jonathan Barronville](https://twitter.com/jonathanmarvens)
 - [Varun Khaneja](https://twitter.com/aawc)
 - [Catt Small](https://www.gittip.com/cattsmall/)
+- [Christopher Clark](https://twitter.com/frencil)


### PR DESCRIPTION
Hello, I'd like to add my name to the list of pledges.

I'm doing so as a rep for my company, SparkFun Electronics. We purchase $250 a month in services from Github and the offset money is out of my SparkFun budget, not my personal wallet. The organizations I selected to benefit from the offset are the [Ada Initiative](https://adainitiative.org/), [PHP Women](http://phpwomen.org/), [Black Girls Code](http://www.blackgirlscode.com/), the [National Center for Women in IT (NCWIT)](http://www.ncwit.org/) and [Girl Develop IT](http://girldevelopit.com/).

Another thing that may be of interest: I've written a post for the SparkFun blog about the GitHub story, the Culture Offset Pledge, and some lessons learned on gender bias in tech, particularly in hiring. It will be accessible at [https://www.sparkfun.com/news/1470](https://www.sparkfun.com/news/1470) sometime on the morning of Tuesday, 4/29. Hopefully it will help continue to draw attention to this project and all the other great organizations and resources out there for women and minorities in tech.

Thanks for setting this up!
